### PR TITLE
bugfix. ended looping the end of the turn between turnmanager and uni…

### DIFF
--- a/Assets/Scripts/Gameplay/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/TurnManager.cs
@@ -55,7 +55,6 @@ public class TurnManager : MonoBehaviour
     {
         UnitMove currentUnit = UnitTurnOrder.Dequeue().Value;
         Debug.Log($"Ending turn for {currentUnit}");
-        currentUnit.EndTurn();
     }
 
     public static void AddUnitToGame(string tag, UnitMove unitMove)


### PR DESCRIPTION
…tmove.

this was causing the full dequeue of the UnitTurnOrder every turn, causing instability and errors due to comparisons on TurnManager's update cycle.