### PR TITLE
Get turn counter up and running.

### DIFF
--- a/Assets/Models.meta
+++ b/Assets/Models.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0b6fa8288574a8748b624d5ed3037506
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/TurnManager.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 
 public class TurnManager : MonoBehaviour
 {
+    // Edit these
+    public float turnSpeedSensitivityMultiplier = 1f;
 
     // ==========Do not change these variables=============
     [HideInInspector]
@@ -14,6 +17,7 @@ public class TurnManager : MonoBehaviour
     private static bool _creatingTurnQueue = false;
     private static bool turnInProgress = false;
     public static CameraController MainCamera;
+    private bool RunningTurnCountdown = false;
     //=====================================================
 
     void Start()
@@ -23,18 +27,37 @@ public class TurnManager : MonoBehaviour
 
     void Update()
     {
-        if (turnInProgress || _creatingTurnQueue)
+        if (turnInProgress || _creatingTurnQueue || RunningTurnCountdown)
         {
             return;
         }
         if (UnitTurnOrder.Count < AllUnits.Count)
-        {
+        {            
             CreateTurnQueue();
+            TurnCountdown();
         }
         if (UnitTurnOrder.Count == AllUnits.Count)
         {
             StartTurn();
         }
+    }
+
+    private void TurnCountdown()
+    {
+        RunningTurnCountdown = true;
+        while (AllUnits.First().Item2._FullTurnCounter > 0)
+        {
+            foreach (var unit in AllUnits)
+            {
+                var countdownUnit = unit.Item2._Speed * turnSpeedSensitivityMultiplier;
+                unit.Item2._FullTurnCounter -= countdownUnit;
+                if (unit.Item2._FullTurnCounter < 0)
+                {
+                    unit.Item2._FullTurnCounter = 0;
+                }
+            }
+        }
+        RunningTurnCountdown = false;
     }
 
     static void CreateTurnQueue()

--- a/Assets/Scripts/Units/MeleeCharacter.cs
+++ b/Assets/Scripts/Units/MeleeCharacter.cs
@@ -8,17 +8,22 @@ public class MeleeCharacter : UnitCharacter
     public float Speed = 10; // higher = faster turn counter
     public float DamageBonus = 0;
     public float DamageResistance = 0; // flat negative to all damage.
-    public float StartingTurnCounterAdd = 10; // adds *once* at the beginning of the game
     public float JumpHeight = 2.0f;
     public int MoveDistance = 5;
+    
+    public float StartingOfGameTurnCounter = 10; // adds *once* at the beginning of the game
+    public float TurnCostToMove = 20f;
+    public float TurnCostToStartTurn = 10f;
 
     void Start()
     {
+        _TurnCostStart = TurnCostToStartTurn;
+        _TurnCostMove = TurnCostToMove;
         _CurrentHealth = StartingHealth;
         _Speed= Speed;
         _DamageResistance= DamageResistance;
-        _FullTurnCounter= StartingTurnCounterAdd;
-        _DamageBonus = DamageBonus;
+        _FullTurnCounter= StartingOfGameTurnCounter;
+        _DamageBonus = DamageBonus;        
         Init();
     }
 
@@ -28,17 +33,14 @@ public class MeleeCharacter : UnitCharacter
         {
             return;
         }
-        Debug.Log($"SPAM OK: Currently taking turn: {_CurrentlyTakingTurn} {this.tag} :: {this}");
         if (!unitMove.currentlyMoving && !_HasMovedThisTurn)
         {
-            Debug.Log($"SPAM OK: checking mouse to move...");
             unitMove.SetAdjacencyList(_JumpHeight);
             unitMove.SetSelectableTiles(JumpHeight, MoveDistance);
             unitMove.CheckMouseToMove();
         }
         if (unitMove.currentlyMoving)
         {
-            Debug.Log($"SHORT SPAM OK: Moving....");
             unitMove.Move();
         }
         if (_HasMovedThisTurn)  // and has attacked this turn....

--- a/Assets/Scripts/Units/UnitCharacter.cs
+++ b/Assets/Scripts/Units/UnitCharacter.cs
@@ -25,6 +25,9 @@ public class UnitCharacter : MonoBehaviour
     public float _JumpHeight;
     [HideInInspector]
     public bool _HasAttackedThisTurn = true; // temporarily true until attacks have been added.
+    protected float _TurnCostStart = 10f;
+    protected float _TurnCostMove = 20f;
+    protected float _TurnCostAttack;
 
     public void Init()
     {
@@ -36,7 +39,7 @@ public class UnitCharacter : MonoBehaviour
     public void BeginTurn()
     {
         Debug.Log($"UnitCharacter starting turn for {this.tag}");
-        _FullTurnCounter += 1;        
+        _FullTurnCounter += _TurnCostStart;        
         _HasMovedThisTurn = false;
         // _HasAttackedThisTurn = false;
         _CurrentlyTakingTurn = true;
@@ -44,7 +47,16 @@ public class UnitCharacter : MonoBehaviour
 
     public void EndTurn()
     {
+        if (_HasMovedThisTurn)
+        {
+            _FullTurnCounter += _TurnCostMove;
+        }
+        if (_HasAttackedThisTurn)
+        {
+            _FullTurnCounter += _TurnCostAttack;
+        }
         _CurrentlyTakingTurn = false;
+        Debug.Log($"{this.tag} unit ending turn with turn counter amount: {_FullTurnCounter}");
         TurnManager.EndTurn();
     }
 }

--- a/Assets/Shaders.meta
+++ b/Assets/Shaders.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3c5e5dae35c00c84c9dd9a2a0c951899
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
- Turn System:
1.  Everyone added to a list with their start-of-game counter (can be defaulted per class and changed per-unit)
2.  Units are sorted by turn counter amount.
3. Turn counters are decreased in increments of a unit's speed until the first unit hits 0.
-- potential issue: units may change order between turns if they have different speeds, causing the turn display to be confusing.
4. Unit takes its turn and is then removed from the unit list. it adds start turn cost, move cost (if move is taken), and attack cost (if attack is taken)
5. Unit that took its turn is added to the turn list
6. repeat at step 2.