### PR TITLE
Unit rotation fix

### DIFF
--- a/Assets/Models.meta
+++ b/Assets/Models.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0b6fa8288574a8748b624d5ed3037506
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Units/MeleeAttack.cs
+++ b/Assets/Scripts/Units/MeleeAttack.cs
@@ -12,7 +12,8 @@ public class MeleeAttack : UnitAttack
     public KeyCode HotKeyAbility1 = KeyCode.G;    
     public float Ability1HeightRestriction = 3f;
     public float Ability1MaxRange = 3f;
-    public float Ability1MinRange = 0f;
+    [HideInInspector]
+    public float Ability1MinRange = 0f;// hiding because NYI
     public float Ability1Damage = 3f;
     public float Ability1TurnCost = 10f;
 
@@ -20,7 +21,8 @@ public class MeleeAttack : UnitAttack
     public KeyCode HotKeyAbility2 = KeyCode.H;    
     public float Ability2HeightRestriction = 10f;
     public float Ability2MaxRange = 5f;
-    public float Ability2MinRange = 3f;
+    [HideInInspector]
+    public float Ability2MinRange = 3f;// hiding because NYI
     public float Ability2Damage = 25f;
     public float Ability2TurnCost = 50f;    
 

--- a/Assets/Scripts/Units/MeleeCharacter.cs
+++ b/Assets/Scripts/Units/MeleeCharacter.cs
@@ -22,10 +22,14 @@ public class MeleeCharacter : UnitCharacter
     public float TurnCostToMove = 20f;
     public float TurnCostToStartTurn = 10f;
 
+    [HideInInspector]
     public bool InAttackPhase = false;
+    [HideInInspector]
     public bool InMovePhase = false;
 
+    [HideInInspector]
     public bool HasAttacked = false;
+    [HideInInspector]
     public bool HasMoved = false;
 
     void Start()

--- a/Assets/Scripts/Units/MeleeMove.cs
+++ b/Assets/Scripts/Units/MeleeMove.cs
@@ -6,9 +6,6 @@ public class MeleeMove : UnitMove
     [Header("Moving")]
     public float MoveSpeed = 10.0f; // how fast the unit traverses the map. This has nothing to do with turn order speed.
 
-    [Header("Jumping")]
-    public float MoveSlowdownMultiplier = 1.0f; // higher = slower movement towards the jump
-
     void Start()
     {
         _unitMoveSpeed = MoveSpeed;

--- a/Assets/Scripts/Units/UnitCharacter.cs
+++ b/Assets/Scripts/Units/UnitCharacter.cs
@@ -96,6 +96,5 @@ public class UnitCharacter : MonoBehaviour
             gameObject.transform.Rotate(rotate90Degrees, Space.Self);
             alreadyDied = true;
         }
-
     }
 }

--- a/Assets/Scripts/Units/UnitMove.cs
+++ b/Assets/Scripts/Units/UnitMove.cs
@@ -14,12 +14,14 @@ public class UnitMove : MonoBehaviour
     protected List<TerrainGeneric> _selectableTiles = new List<TerrainGeneric>();
     protected Stack<TerrainGeneric> _movePath = new Stack<TerrainGeneric>();
     protected GameObject[] allTiles;
+    private List<TerrainGeneric> moveTracking = new List<TerrainGeneric>();
     
     [HideInInspector]
     public bool currentlyMoving = false;
     protected Vector3 moveVelocity = new Vector3();
     [HideInInspector]
     public Vector3 moveHeading = new Vector3();
+    private Quaternion lastRotation = new Quaternion();
     [HideInInspector]
     public bool _hasMoved = false;
     private Quaternion originalRotation;
@@ -69,10 +71,12 @@ public class UnitMove : MonoBehaviour
 
                 transform.forward = moveHeading;
                 transform.position += moveVelocity * Time.deltaTime;
+                
             }
             else
             {
-                transform.position = moveTarget;                
+                transform.position = moveTarget;
+                lastRotation = Quaternion.Euler(transform.rotation.x, transform.rotation.y, transform.rotation.z);
                 _movePath.Pop();
             }
         }
@@ -176,10 +180,8 @@ public class UnitMove : MonoBehaviour
     #region Move-specific
 
     private void FixUnitRotation()
-    {       
-        
-        transform.rotation = originalRotation;
-        //transform.position.Normalize();
+    {
+        transform.rotation = lastRotation;        
     }
 
     public void SetMoveVelocity()
@@ -221,8 +223,8 @@ public class UnitMove : MonoBehaviour
 
     public void SetHeadingDirection(Vector3 targetDirection)
     {
-        moveHeading = targetDirection - transform.position;
-        moveHeading.Normalize();
+        moveHeading = targetDirection - transform.position;        
+        moveHeading.Normalize();        
     }
 
     #endregion

--- a/Assets/Scripts/Units/UnitMove.cs
+++ b/Assets/Scripts/Units/UnitMove.cs
@@ -62,7 +62,7 @@ public class UnitMove : MonoBehaviour
             TerrainGeneric nextTile = _movePath.Peek();         
             Vector3 moveTarget = nextTile.transform.position;
             moveTarget.y += halfUnitHeight + nextTile.GetComponent<Collider>().bounds.extents.y;
-            if (Vector3.Distance(transform.position, moveTarget) >= tileCenterFudge - .01f) // .01f because we want the unit to "get there" before anything else happens
+            if (Vector3.Distance(transform.position, moveTarget) >= tileCenterFudge)
             {
                 SetHeadingDirection(moveTarget);
                 SetMoveVelocity();
@@ -72,15 +72,13 @@ public class UnitMove : MonoBehaviour
             }
             else
             {
-                transform.rotation = originalRotation;
-                transform.forward = moveHeading;
-                transform.position = moveTarget;
+                transform.position = moveTarget;                
                 _movePath.Pop();
             }
         }
         else
         {
-            
+            FixUnitRotation();
             ClearSelectableTiles();
             currentlyMoving = false;
             _hasMoved = true;
@@ -176,6 +174,13 @@ public class UnitMove : MonoBehaviour
     #endregion
 
     #region Move-specific
+
+    private void FixUnitRotation()
+    {       
+        
+        transform.rotation = originalRotation;
+        //transform.position.Normalize();
+    }
 
     public void SetMoveVelocity()
     {

--- a/Assets/Scripts/Units/UnitMove.cs
+++ b/Assets/Scripts/Units/UnitMove.cs
@@ -21,6 +21,7 @@ public class UnitMove : MonoBehaviour
     protected Vector3 moveVelocity = new Vector3();
     [HideInInspector]
     public Vector3 moveHeading = new Vector3();
+    public Vector3 lastHeading = new Vector3();
     private Quaternion lastRotation = new Quaternion();
     [HideInInspector]
     public bool _hasMoved = false;
@@ -66,6 +67,7 @@ public class UnitMove : MonoBehaviour
             moveTarget.y += halfUnitHeight + nextTile.GetComponent<Collider>().bounds.extents.y;
             if (Vector3.Distance(transform.position, moveTarget) >= tileCenterFudge)
             {
+                lastHeading = moveHeading;
                 SetHeadingDirection(moveTarget);
                 SetMoveVelocity();
 
@@ -76,16 +78,17 @@ public class UnitMove : MonoBehaviour
             else
             {
                 transform.position = moveTarget;
-                lastRotation = Quaternion.Euler(transform.rotation.x, transform.rotation.y, transform.rotation.z);
+                lastRotation = transform.rotation;                
                 _movePath.Pop();
             }
         }
         else
         {
-            FixUnitRotation();
+            
             ClearSelectableTiles();
             currentlyMoving = false;
             _hasMoved = true;
+            FixUnitRotation();
         }
     }
 
@@ -181,7 +184,8 @@ public class UnitMove : MonoBehaviour
 
     private void FixUnitRotation()
     {
-        transform.rotation = lastRotation;        
+        var rotDegrees = Quaternion.Euler(originalRotation.eulerAngles.x - lastRotation.eulerAngles.x, 0, 0);
+        transform.Rotate(rotDegrees.eulerAngles, Space.Self);
     }
 
     public void SetMoveVelocity()


### PR DESCRIPTION
- Unit Rotation is now fixed after every move. Units will keep their heading/facing, but rotate back to "flat on the ground" after movement up/down terrain.
- Cleaned up some unusable vars in base classes so they are now hidden in the inspector.
- Removed jump variables and functions, as we are no longer "Jumping" in this game.

All available options in inspector should be available for tweaking in prefabs. if one is found that is not functional, please put in a bug or hit me up directly.