### PR TITLE
Update the turn banner in the upper left with correct team info.

### DIFF
--- a/Assets/Scripts/Gameplay/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/TurnManager.cs
@@ -39,8 +39,6 @@ public class TurnManager : MonoBehaviour
     public static int _LivingUnits = 0;    
     public UnitCharacter _CurrentlyActiveUnit;
     [HideInInspector]
-    public CurrentCharacterInformation UiCharInfo;
-    [HideInInspector]
     private UnitLists UiUnitLists;
     [HideInInspector]
     public ActionButtons actionButtons;
@@ -49,7 +47,6 @@ public class TurnManager : MonoBehaviour
     void Start()
     {
         UiUnitLists = GameObject.FindObjectOfType<UnitLists>();
-        UiCharInfo = GameObject.FindObjectOfType<CurrentCharacterInformation>();
         MainCamera = GameObject.FindGameObjectWithTag("MainCamera").GetComponentInParent<CameraController>();
         actionButtons = GameObject.FindObjectOfType<ActionButtons>();
         Init();
@@ -150,7 +147,7 @@ public class TurnManager : MonoBehaviour
         turnInProgress = true;
         var nextUnit = UnitTurnOrder.Peek();
         Debug.Log($"TurnManager starting turn." +
-            $"\nPlayer Tag: {nextUnit.Item1}");        
+            $"\nPlayer Tag: {nextUnit.Item1}");
         nextUnit.Item2.BeginTurn();
         Debug.Log($"auto-panning camera to {nextUnit.Item2}");
         MainCamera.PanCameraToLocation(nextUnit.Item2.transform.position);

--- a/Assets/Scripts/UI/PlayArea.meta
+++ b/Assets/Scripts/UI/PlayArea.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a166e6ec0d5748a4b82e4cb387725c27
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/PlayArea/PlayerTurn.cs
+++ b/Assets/Scripts/UI/PlayArea/PlayerTurn.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+
+enum Teams
+{
+    Player0, // Do not use. This is a placeholder that will work with player team tags.
+    Player1,
+    Player2
+}
+
+public class PlayerTurn : MonoBehaviour
+{
+    public Color Player1Color = Color.blue;
+    public Color Player2Color = Color.red;
+    public string Team1Name = "ChangeMe1";
+    public string Team2Name = "ChangeMe2";
+    
+    [HideInInspector]
+    private Teams currentTeam;
+    [HideInInspector]
+    private string currentTeamName;
+    [HideInInspector]
+    private Color currentTeamColor;
+    
+    [HideInInspector]
+    public Text playerTurnText;
+    [HideInInspector]
+    public TurnManager turnManager;
+    
+    void Start()
+    {
+        turnManager = FindObjectOfType<TurnManager>();
+        playerTurnText = GetComponent<Text>();
+    }
+
+    void Update()
+    {
+        if (currentTeam != (Teams)int.Parse(turnManager._CurrentlyActiveUnit.tag.Last().ToString()))
+        {
+            UpdatePlayerTurnUiBanner();
+        }
+    }
+
+    public void UpdatePlayerTurnUiBanner()
+    {
+        SetCurrentTeam();
+        playerTurnText.text = $"{currentTeamName}'s Turn";
+        playerTurnText.color = currentTeamColor;
+    }
+
+    private void SetCurrentTeam()
+    {
+        currentTeam = (Teams)int.Parse(turnManager._CurrentlyActiveUnit.tag.Last().ToString());
+        switch (currentTeam)
+        {
+            case Teams.Player0:
+                throw new System.Exception("no such thing as player 0. update to different player tag.");
+            case Teams.Player1:
+                currentTeamColor = Player1Color;
+                currentTeamName = Team1Name;
+                break;
+            case Teams.Player2:
+                currentTeamColor = Player2Color;
+                currentTeamName = Team2Name;
+                break;
+            default:
+                throw new System.Exception("Unable to use this unit's tag to determine team. Ensure the unit has the correct team/player tag.");
+        }
+    }
+}

--- a/Assets/Scripts/UI/PlayArea/PlayerTurn.cs.meta
+++ b/Assets/Scripts/UI/PlayArea/PlayerTurn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 171161951218b2d4cbc4dc9ac363b5e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Team banner now shows a customizable name and customizable color (can be set in the editor)
- The script PlayerTurn has been added to the banner PlayerTurnText gameObject. This should not be removed.