### PR TITLE
TG-39 - Portraits are not updating on death; death breaks the game.

### DIFF
--- a/Assets/Models.meta
+++ b/Assets/Models.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0b6fa8288574a8748b624d5ed3037506
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/TurnManager.cs
+++ b/Assets/Scripts/Gameplay/TurnManager.cs
@@ -120,11 +120,8 @@ public class TurnManager : MonoBehaviour
         _LivingUnits = 0;
         foreach (var unit in AllUnits)
         {
-            if (!unit.Item2._IsDead)
-            {
-                _LivingUnits++;
-                UnitTurnOrder.Enqueue(unit);
-            }
+            _LivingUnits++;
+            UnitTurnOrder.Enqueue(unit);
         }
         _creatingTurnQueue = false;        
     }
@@ -160,7 +157,7 @@ public class TurnManager : MonoBehaviour
 
     public static void EndTurn()
     {        
-        var currentUnit = UnitTurnOrder.Dequeue();
+        var unit = UnitTurnOrder.Dequeue();
         _TurnCounter++;
         turnInProgress = false;
     }
@@ -176,7 +173,7 @@ public class TurnManager : MonoBehaviour
         }
     }
 
-    #region ClickableActions
+    #region Debug Clickable Actions
     
     public void DisplayWinnerScreen()
     {

--- a/Assets/Scripts/UI/RightPanel/UnitLists.cs
+++ b/Assets/Scripts/UI/RightPanel/UnitLists.cs
@@ -50,10 +50,20 @@ public class UnitLists : MonoBehaviour
         for (int i = 0; i < aliveDeadList.Count; i++)
         {
             sideBarDisplay[i].Item1.text = aliveDeadList[i]._UnitName;
-            sideBarDisplay[i].Item2.sprite = i < TurnOrderList.Count ? aliveDeadList[i].UnitPortraitAlive.sprite : aliveDeadList[i].UnitPortraitDead.sprite;
             sideBarDisplay[i].Item3.minValue = 0;
             sideBarDisplay[i].Item3.maxValue = aliveDeadList[i]._MaximumHealth;
             sideBarDisplay[i].Item3.value = aliveDeadList[i]._CurrentHealth;
+            if (aliveDeadList[i]._IsDead)
+            {
+                sideBarDisplay[i].Item2.enabled = true;
+                sideBarDisplay[i].Item2.sprite = aliveDeadList[i].UnitPortraitDead.sprite;
+                
+            }
+            else if (!aliveDeadList[i]._IsDead)
+            {
+                sideBarDisplay[i].Item2.enabled = true;
+                sideBarDisplay[i].Item2.sprite = aliveDeadList[i].UnitPortraitAlive.sprite;
+            }
         }
     }
 

--- a/Assets/Scripts/Units/MeleeCharacter.cs
+++ b/Assets/Scripts/Units/MeleeCharacter.cs
@@ -53,33 +53,33 @@ public class MeleeCharacter : UnitCharacter
 
     void Update()
     {
-        if (_CurrentHealth <= 0)
+        if (_CurrentHealth <= 0 && !alreadyDied)
         {
             _CurrentHealth = 0;
-            _IsDead = true;
-        }
-        if (_IsDead)
-        {
             ActivateDeath();
         }
-        if (!_CurrentlyTakingTurn)
+        else if (_IsDead && alreadyDied && _CurrentlyTakingTurn)
+        {
+            EndTurn();
+        }
+        else if (!_CurrentlyTakingTurn)
         {
             return;
         }
-        if (_InMovePhase || _InAttackPhase)
+        else if (_InMovePhase || _InAttackPhase)
         {
             return;
         }
-        if (Input.GetKeyUp(HotkeyMove) && _MovesLeftThisTurn > 0)
+        else if (Input.GetKeyUp(HotkeyMove) && _MovesLeftThisTurn > 0)
         {
             
             unitMove.StartMovePhase();
         }
-        if (Input.GetKeyUp(HotkeyAttack) && _AttacksLeftThisTurn > 0)
+        else if (Input.GetKeyUp(HotkeyAttack) && _AttacksLeftThisTurn > 0)
         {
             unitAttack.StartAttackPhase();
         }
-        if (Input.GetKeyUp(HotkeyEndTurn))
+        else if (Input.GetKeyUp(HotkeyEndTurn))
         {
             EndTurn();
         }

--- a/Assets/Scripts/Units/UnitCharacter.cs
+++ b/Assets/Scripts/Units/UnitCharacter.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -49,7 +50,7 @@ public class UnitCharacter : MonoBehaviour
     [HideInInspector]
     public bool _IsDead = false;
     [HideInInspector]
-    private bool alreadyDied = false;
+    public bool alreadyDied = false;
     [HideInInspector]
     public bool _InMovePhase = false;
     [HideInInspector]
@@ -78,17 +79,31 @@ public class UnitCharacter : MonoBehaviour
 
     public void BeginTurn()
     {
-        Debug.Log($"UnitCharacter starting turn for {this.tag}");
-        _FullTurnCounter += _TurnCostStart;
-        _InMovePhase = false;
-        _InAttackPhase = false;
-        _AttacksLeftThisTurn = _AvailableAttacksPerTurn;
-        _MovesLeftThisTurn = _AvailableMovesPerTurn;
-        _CurrentlyTakingTurn = true;
-        turnManager._CurrentlyActiveUnit = this;
-        unitMove.SetCurrentTile();
-        _Ui.UpdateCurrentCharacter(this);
-        turnManager.UpdateSidebarUi();
+        if (_IsDead)
+        {
+            _InMovePhase = false;
+            _InAttackPhase = false;
+            _AttacksLeftThisTurn = 0;
+            _MovesLeftThisTurn = 0;
+            _CurrentlyTakingTurn = true;
+            turnManager._CurrentlyActiveUnit = this;
+            _FullTurnCounter += 1000;
+            turnManager.UpdateSidebarUi();
+        }
+        else
+        {
+            Debug.Log($"UnitCharacter starting turn for {this.tag}");
+            _FullTurnCounter += _TurnCostStart;
+            _InMovePhase = false;
+            _InAttackPhase = false;
+            _AttacksLeftThisTurn = _AvailableAttacksPerTurn;
+            _MovesLeftThisTurn = _AvailableMovesPerTurn;
+            _CurrentlyTakingTurn = true;
+            turnManager._CurrentlyActiveUnit = this;
+            unitMove.SetCurrentTile();
+            _Ui.UpdateCurrentCharacter(this);
+            turnManager.UpdateSidebarUi();
+        }
     }
 
     public void EndTurn()
@@ -104,8 +119,11 @@ public class UnitCharacter : MonoBehaviour
     {
         if (!alreadyDied)
         {
-            var rotate90Degrees = new Vector3(transform.rotation.x + 90, transform.rotation.y, transform.rotation.z);
+            var rotate90Degrees = Quaternion.Euler(transform.rotation.x - 90, transform.rotation.y, transform.rotation.z).eulerAngles;
             gameObject.transform.Rotate(rotate90Degrees, Space.Self);
+            //gameObject.transform.position -= new Vector3(0, 0, Math.Abs(transform.position.y - unitMove.halfUnitHeight + .1f));
+            _IsDead = true;
+            _FullTurnCounter += 1000;
             alreadyDied = true;
         }
     }


### PR DESCRIPTION
- Updated TurnManager to include dead units in turn order, and added 1000 to their turn counter upon death.
-- this is most likely a temporary measure that will require tech debt in the future until a permanent dynamic UI solution is found. This will allow dead units to live in their own space, and allow full unit counts to include dead units not in the turn order.
- hardened unit portrait updating to be more precise. updating the portrait now checks if the unit is dead instead of "after the living units".