### PR TITLE
UI Clickthrough disabled.

### DIFF
--- a/Assets/Models.meta
+++ b/Assets/Models.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0b6fa8288574a8748b624d5ed3037506
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Units/UnitAttack.cs
+++ b/Assets/Scripts/Units/UnitAttack.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 public class UnitAttack : MonoBehaviour
 {
@@ -62,7 +63,7 @@ public class UnitAttack : MonoBehaviour
 
     public void CheckMouseToAttack()
     {
-        if (Input.GetMouseButtonUp(0))
+        if (Input.GetMouseButtonUp(0) && !EventSystem.current.IsPointerOverGameObject())
         {
             Ray mouseCheck = Camera.main.ScreenPointToRay(Input.mousePosition);
 

--- a/Assets/Scripts/Units/UnitMove.cs
+++ b/Assets/Scripts/Units/UnitMove.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 public class UnitMove : MonoBehaviour
 {
@@ -205,7 +206,7 @@ public class UnitMove : MonoBehaviour
 
     public void CheckMouseToMove()
     {
-        if (Input.GetMouseButtonUp(0))
+        if (Input.GetMouseButtonUp(0) && !EventSystem.current.IsPointerOverGameObject())
         {
             Ray mouseCheck = Camera.main.ScreenPointToRay(Input.mousePosition);
 


### PR DESCRIPTION
- Moving and Attacking will now check for "action" clicks and disable them if the mouse is over the UI.